### PR TITLE
Upgrading to last Neo4j and other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ tmp/
 local.properties
 .settings/
 .loadpath
+.project
 
 # External tool builders
 .externalToolBuilders/

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ local.properties
 .settings/
 .loadpath
 .project
+.classpath
 
 # External tool builders
 .externalToolBuilders/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: java
-
-jdk: oraclejdk8
+jdk:
+  - oraclejdk8  
+script: mvn deploy --settings settings.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 jdk:
   - oraclejdk8  
-script: mvn deploy --settings settings.xml
+script: mvn deploy --settings settings.xml -P ondexDeploy

--- a/README.md
+++ b/README.md
@@ -59,6 +59,33 @@ For an example, run
     cd integration-tests
     mvn clean verify
 
+The server might take a while before going on line, so your tests might get connection refused errors. This
+ant-based pause might help (must go after the neo4j plug-in declaration above):
+
+```
+<plugin>
+	<groupId>org.apache.maven.plugins</groupId>
+	<artifactId>maven-antrun-plugin</artifactId>
+	<version>1.8</version>
+	<executions>
+		<execution>
+			<id>wait</id>
+			<phase>pre-integration-test</phase>
+			<configuration>
+				<target>
+					<echo message = "Waiting for Neo4j to boot" />
+					<sleep seconds="3" />
+				</target>
+			</configuration>
+			<goals>
+				<goal>run</goal>
+			</goals>
+		</execution>
+	</executions>
+</plugin>
+```
+
+
 ### Releases
 
 This project uses the [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/) to

--- a/README.md
+++ b/README.md
@@ -59,33 +59,10 @@ For an example, run
     cd integration-tests
     mvn clean verify
 
-The server might take a while before going on line, so your tests might get connection refused errors. This
-ant-based pause might help (must go after the neo4j plug-in declaration above):
+### Parameters
 
-```
-<plugin>
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-antrun-plugin</artifactId>
-	<version>1.8</version>
-	<executions>
-		<execution>
-			<id>wait</id>
-			<phase>pre-integration-test</phase>
-			<configuration>
-				<target>
-					<echo message = "Waiting for Neo4j to boot" />
-					<sleep seconds="3" />
-				</target>
-			</configuration>
-			<goals>
-				<goal>run</goal>
-			</goals>
-		</execution>
-	</executions>
-</plugin>
-```
-
-
+Have a look at the `[com.github.harti2006.neo4j.Neo4jServerMojoSupport](TODO)` class for details.
+ 
 ### Releases
 
 This project uses the [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/) to

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ and runs it, as a user would do it, using `./neo4j start`
 
 Furthermore it provides an idiomatic way to configure the server using the plugin `<configuration>` section.
 
+**This is a fork** made in the the [kNetMiner project](http://knetminer.rothamsted.ac.uk/), to upgrade the 
+plug-in to the last Neo4J version and deploy on our [organisation repository](http://ondex.rothamsted.ac.uk/nexus/index.html).
+
 ## Building the project
 
     mvn clean install

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.github.harti2006</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -16,10 +16,13 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <neo4j-server.port>7676</neo4j-server.port>
-        <neo4j-server.version>2.1.7</neo4j-server.version>
+        <neo4j-server.boltPort>8686</neo4j-server.boltPort>
+        <neo4j-server.password>testPass</neo4j-server.password>
+
+        <neo4j-server.version>3.3.1</neo4j-server.version>
 
         <maven-failsafe-plugin.version>2.18.1</maven-failsafe-plugin.version>
-        <neo4j-server-maven-plugin.version>1.0-SNAPSHOT</neo4j-server-maven-plugin.version>
+        <neo4j-server-maven-plugin.version>${project.version}</neo4j-server-maven-plugin.version>
 
         <junit.version>4.12</junit.version>
         <spring-web.version>4.1.4.RELEASE</spring-web.version>
@@ -38,6 +41,12 @@
             <version>${spring-web.version}</version>
             <scope>test</scope>
         </dependency>
+				<dependency>
+ 						<groupId>org.neo4j.driver</groupId>
+						<artifactId>neo4j-java-driver</artifactId>
+						<version>1.4.5</version>
+						<scope>test</scope>
+				</dependency>            			      
     </dependencies>
 
     <build>
@@ -45,19 +54,25 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${maven-failsafe-plugin.version}</version>
+                <configuration>
+                    <systemProperties>
+											<neo4j-server.port>${neo4j-server.port}</neo4j-server.port>
+											<neo4j-server.boltPort>${neo4j-server.boltPort}</neo4j-server.boltPort>
+											<neo4j-server.password>${neo4j-server.password}</neo4j-server.password>
+                    </systemProperties>
+                </configuration>
                 <executions>
                     <execution>
                         <id>run-integration-tests</id>
                         <goals>
                             <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>verify-integration-tests</id>
+                        <goals>
                             <goal>verify</goal>
                         </goals>
-                        <configuration>
-                            <systemProperties>
-                                <neo4j-server.url>http://localhost:${neo4j-server.port}
-                                </neo4j-server.url>
-                            </systemProperties>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -68,7 +83,9 @@
                 <version>${neo4j-server-maven-plugin.version}</version>
                 <configuration>
                     <port>${neo4j-server.port}</port>
-                    <version>${neo4j-server.version}</version>
+                    <boltPort>${neo4j-server.boltPort}</boltPort>
+                    <password>${neo4j-server.password}</password>
+                    <version>${neo4j-server.version}</version>                    
                 </configuration>
                 <executions>
                     <execution>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -35,12 +35,6 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-web</artifactId>
-            <version>${spring-web.version}</version>
-            <scope>test</scope>
-        </dependency>
 				<dependency>
  						<groupId>org.neo4j.driver</groupId>
 						<artifactId>neo4j-java-driver</artifactId>
@@ -55,11 +49,12 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${maven-failsafe-plugin.version}</version>
                 <configuration>
-                    <systemProperties>
-											<neo4j-server.port>${neo4j-server.port}</neo4j-server.port>
-											<neo4j-server.boltPort>${neo4j-server.boltPort}</neo4j-server.boltPort>
-											<neo4j-server.password>${neo4j-server.password}</neo4j-server.password>
-                    </systemProperties>
+									<trimStackTrace>false</trimStackTrace>
+									<systemProperties>
+										<neo4j-server.port>${neo4j-server.port}</neo4j-server.port>
+										<neo4j-server.boltPort>${neo4j-server.boltPort}</neo4j-server.boltPort>
+										<neo4j-server.password>${neo4j-server.password}</neo4j-server.password>
+									</systemProperties>
                 </configuration>
                 <executions>
                     <execution>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -85,7 +85,8 @@
                     <port>${neo4j-server.port}</port>
                     <boltPort>${neo4j-server.boltPort}</boltPort>
                     <password>${neo4j-server.password}</password>
-                    <version>${neo4j-server.version}</version>                    
+                    <version>${neo4j-server.version}</version>
+                    <deleteDb>true</deleteDb>                    
                 </configuration>
                 <executions>
                     <execution>

--- a/integration-tests/src/test/java/com/github/harti2006/Neo4jServerIT.java
+++ b/integration-tests/src/test/java/com/github/harti2006/Neo4jServerIT.java
@@ -26,11 +26,12 @@ public class Neo4jServerIT {
     @Test
     public void testNeo4jServerIsRunning() throws Exception 
     {
-    		// We test the bolt server here, the web interface is not crucial for applications. 
+    		// We test the bolt server here, the web interface is not crucial for Maven builds. 
     		String boltPort = System.getProperty ( "neo4j-server.boltPort" );
     		String pwd = System.getProperty ( "neo4j-server.password" );
-    		
-      Driver driver = GraphDatabase.driver( "bolt://127.0.0.1:" + boltPort, AuthTokens.basic ( "neo4j", pwd ) );
-      driver.close ();
+    		try (
+  				Driver driver = GraphDatabase.driver( "bolt://127.0.0.1:" + boltPort, AuthTokens.basic ( "neo4j", pwd ) );
+    		) {
+    		}
     }
 }

--- a/integration-tests/src/test/java/com/github/harti2006/Neo4jServerIT.java
+++ b/integration-tests/src/test/java/com/github/harti2006/Neo4jServerIT.java
@@ -15,27 +15,22 @@
 
 package com.github.harti2006;
 
-import static java.net.URI.create;
-import static org.junit.Assert.assertEquals;
-import static org.springframework.http.HttpStatus.OK;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-
 import org.junit.Test;
-import org.springframework.http.RequestEntity;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.client.RestTemplate;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+
 
 public class Neo4jServerIT {
 
     @Test
-    public void testNeo4jServerIsRunning() throws Exception {
-        final RestTemplate restTemplate = new RestTemplate();
-        final RequestEntity<Void> request = RequestEntity.get(create(System.getProperty("neo4j-server.url")))
-                .accept(APPLICATION_JSON)
-                .build();
-        final ResponseEntity<String> responseEntity = restTemplate.exchange(request, String.class);
-
-        assertEquals(OK, responseEntity.getStatusCode());
-        System.out.println(responseEntity);
+    public void testNeo4jServerIsRunning() throws Exception 
+    {
+    		// We test the bolt server here, the web interface is not crucial for applications. 
+    		String boltPort = System.getProperty ( "neo4j-server.boltPort" );
+    		String pwd = System.getProperty ( "neo4j-server.password" );
+    		
+      Driver driver = GraphDatabase.driver( "bolt://127.0.0.1:" + boltPort, AuthTokens.basic ( "neo4j", pwd ) );
+      driver.close ();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,19 @@
             <artifactId>jarchivelib</artifactId>
             <version>${jarchivelib.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <version>4.1.4.RELEASE</version>
+        </dependency>
+
+				<dependency>
+ 						<groupId>org.neo4j.driver</groupId>
+						<artifactId>neo4j-java-driver</artifactId>
+						<version>1.4.5</version>
+				</dependency>            			      
+
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,13 @@
 
         <commons-io.version>2.4</commons-io.version>
         <jarchivelib.version>0.7.0</jarchivelib.version>
+
+				<distro.id>ossrh</distro.id>
+				<distro.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distro.url>
+
+				<distro.snap.id>ossrh-snapshots</distro.snap.id>
+				<distro.snap.url>https://oss.sonatype.org/content/repositories/snapshots</distro.snap.url>
+        
     </properties>
 
     <dependencies>
@@ -141,16 +148,18 @@
     </profiles>
 
     <distributionManagement>
-      <repository>
-         <id>ondex-releases</id>
-         <name>Internal Releases</name>
-         <url>http://ondex.rothamsted.ac.uk/nexus/content/repositories/releases</url>
-      </repository>
+
+			<!-- This way we can play with settings and profile and select alternative distro repos. -->
+			
       <snapshotRepository>
-         <id>ondex-snapshots</id>
-         <name>Internal Snapshots</name>
-         <url>http://ondex.rothamsted.ac.uk/nexus/content/repositories/snapshots</url>
+          <id>${distro.snap.id}</id>
+          <url>${distro.snap.url}</url>
       </snapshotRepository>
+      <repository>
+          <id>${distro.id}</id>
+          <url>${distro.url}</url>
+      </repository>
+      
     </distributionManagement>
       
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -124,24 +124,26 @@
                 </plugins>
             </build>
         </profile>
+        
     </profiles>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
+      <repository>
+         <id>ondex-releases</id>
+         <name>Internal Releases</name>
+         <url>http://ondex.rothamsted.ac.uk/nexus/content/repositories/releases</url>
+      </repository>
+      <snapshotRepository>
+         <id>ondex-snapshots</id>
+         <name>Internal Snapshots</name>
+         <url>http://ondex.rothamsted.ac.uk/nexus/content/repositories/snapshots</url>
+      </snapshotRepository>
     </distributionManagement>
-
+      
     <scm>
-        <url>https://github.com/harti2006/neo4j-server-maven-plugin</url>
+        <url>https://github.com/Rothamsted/neo4j-server-maven-plugin</url>
         <connection>scm:git:https://github.com/harti2006/neo4j-server-maven-plugin.git</connection>
-        <developerConnection>scm:git:https://github.com/harti2006/neo4j-server-maven-plugin.git
-        </developerConnection>
+        <developerConnection>scm:git:https://github.com/Rothamsted/neo4j-server-maven-plugin.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/settings.xml
+++ b/settings.xml
@@ -1,6 +1,7 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
-  <!-- These are used by Travis -->
+  <!-- These are used by Rothamsted/Travis and override the original harti's distro server -->
+    
   <servers>
 
     <server>
@@ -16,5 +17,20 @@
     </server>
 
   </servers>
+
+	<profiles>
+		<profile>
+			<id>ondexDeploy</id>
+			<activation><activeByDefault>true</activeByDefault></activation>
+			<properties>
+				<distro.id>ondex-releases</distro.id>
+				<distro.url>http://ondex.rothamsted.ac.uk/nexus/content/repositories/releases</distro.url>
+
+				<distro.snap.id>ondex-snapshots</distro.snap.id>
+				<distro.snap.url>http://ondex.rothamsted.ac.uk/nexus/content/repositories/snapshots</distro.snap.url>			
+			</properties>
+		</profile>
+		
+	</profiles>
 
 </settings>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,20 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- These are used by Travis -->
+  <servers>
+
+    <server>
+      <id>ondex-snapshots</id>
+      <username>${env.REPO_USER}</username>
+      <password>${env.REPO_PWD}</password>
+    </server>
+
+    <server>
+      <id>ondex-releases</id>
+      <username>${env.REPO_USER}</username>
+      <password>${env.REPO_PWD}</password>
+    </server>
+
+  </servers>
+
+</settings>

--- a/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
+++ b/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
@@ -37,13 +37,36 @@ public abstract class Neo4jServerMojoSupport extends AbstractMojo {
             defaultValue = "${project.build.directory}/neo4j-server")
     protected String directory;
 
+    /**
+     * The web interface port, default is the same as Neo4J default.
+     */
     @Parameter(required = true, property = "neo4j-server.port", defaultValue = "7474")
     protected String port;
 
+    	/**
+    	 * The BOLT protocol port. This is what the programmatic clients use to access Neo4J. Default is 
+    	 * the same as Neo4J default.
+    	 * 
+    	 */
     @Parameter(required = true, property = "neo4j-server.boltPort", defaultValue = "7687")
     protected String boltPort;
 
-
+    /**
+     * The new Neo4J password. Neo4j creates a default neo4j/neo4j account of each new database, which is 
+     * set as expired and it can be used only to setup a new password. So the start procedure does that
+     * with this parameter.
+     */
+    @Parameter(required = true, property = "neo4j-server.password", defaultValue = "test")
+    	protected String password;
+    	
+    
+    /**
+     * Whether the neo4j DB must be cleaned or not before starting a new server with the start goal.
+     * You'll want to leave this set to the true default value in most cases.
+     */
+    @Parameter(required = true, property = "neo4j-server.deleteDb", defaultValue = "true")
+    	protected boolean deleteDb;
+    	
     protected Path getServerLocation() {
         return Paths.get(directory, ARTIFACT_NAME + version);
     }

--- a/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
+++ b/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
@@ -62,9 +62,10 @@ public abstract class Neo4jServerMojoSupport extends AbstractMojo {
     
     /**
      * Whether the neo4j DB must be cleaned or not before starting a new server with the start goal.
-     * You'll want to leave this set to the true default value in most cases.
+     * Typically, you want this to be false when you manually restart the test server, by invoking 
+     * this plug-in via command line, and you want it to be true when you configure a POM. 
      */
-    @Parameter(required = true, property = "neo4j-server.deleteDb", defaultValue = "true")
+    @Parameter(required = true, property = "neo4j-server.deleteDb", defaultValue = "false")
     	protected boolean deleteDb;
     	
     protected Path getServerLocation() {

--- a/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
+++ b/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
@@ -37,8 +37,12 @@ public abstract class Neo4jServerMojoSupport extends AbstractMojo {
             defaultValue = "${project.build.directory}/neo4j-server")
     protected String directory;
 
-    @Parameter(required = true, property = "neo4j-server.port", defaultValue = "7575")
+    @Parameter(required = true, property = "neo4j-server.port", defaultValue = "7474")
     protected String port;
+
+    @Parameter(required = true, property = "neo4j-server.boltPort", defaultValue = "7687")
+    protected String boltPort;
+
 
     protected Path getServerLocation() {
         return Paths.get(directory, ARTIFACT_NAME + version);

--- a/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
+++ b/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
@@ -84,11 +84,13 @@ public class StartNeo4jServerMojo extends Neo4jServerMojoSupport {
     private void configureNeo4jServer() throws MojoExecutionException {
         final Path serverLocation = getServerLocation();
         final Path serverPropertiesPath = serverLocation.resolve(
-                Paths.get("conf", "neo4j-server.properties"));
+                Paths.get("conf", "neo4j.conf"));
 
-        final Properties serverProperties = PropertyUtils.loadProperties(serverPropertiesPath.toFile());
-        serverProperties.setProperty("org.neo4j.server.webserver.port", port);
-        serverProperties.setProperty("org.neo4j.server.webserver.https.enabled", "false");
+        Properties serverProperties = PropertyUtils.loadProperties(serverPropertiesPath.toFile());
+
+        serverProperties.setProperty("dbms.connector.http.listen_address", "localhost:" + port);
+        serverProperties.setProperty("dbms.connector.bolt.listen_address", "localhost:" + boltPort);
+        serverProperties.setProperty("dbms.connector.https.enabled", "false");
 
         try {
             serverProperties.store(newBufferedWriter(serverPropertiesPath, TRUNCATE_EXISTING, WRITE),

--- a/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
+++ b/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
@@ -150,7 +150,7 @@ public class StartNeo4jServerMojo extends Neo4jServerMojoSupport {
     private void checkServerReady () throws MojoExecutionException, InterruptedException
     {
     		String pwd = deleteDb ? "neo4j" : password;
-    		int maxAttempts = 5;
+    		int maxAttempts = 10;
     		Thread.sleep ( 1500 ); // It takes some time anyway
     		
       for ( int attempts = 1; attempts <= maxAttempts ; attempts++ )

--- a/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
+++ b/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
@@ -165,12 +165,14 @@ public class StartNeo4jServerMojo extends Neo4jServerMojoSupport {
     private void checkServerReady () throws MojoExecutionException, InterruptedException
     {
     		String pwd = deleteDb ? "neo4j" : password;
+    		int maxAttempts = 3;
+    		Thread.sleep ( 1500 ); // It takes some time anyway
     		
-      for ( int attempts = 3; attempts > 0; attempts-- )
+      for ( int attempts = 1; attempts <= maxAttempts ; attempts++ )
       {
       		try 
       		{
-      			getLog().info ( "Trying to connect DB with pass: " + pwd ); 
+      			getLog().debug ( "Trying to connect Neo4j, attempt " + attempts ); 
 	        Driver driver = GraphDatabase.driver( "bolt://127.0.0.1:" + boltPort, AuthTokens.basic ( "neo4j", pwd ) );
 	      		driver.close ();
 	      		return;


### PR DESCRIPTION
Hi, 

I've just discovered this plug-in and I find it very useful! I've upgraded it to work with the last Neo4j (mainly, they've changed the server configuration name and the parameter names in it).

I've also added [Travis](https://travis-ci.org/) config files, to have the plug-in built automatically, everytime a commit reaches GitHub.

I've added a couple of Eclipse-related entries in .gitignore.

For the moment, the POM contains our organisation's artifactory as deployment destination. I would be happy to either swirch back to your own repo, or setup the POM so that this is configurable via external profiles defined in settings.xml.

I've also changed the README, to explain how the start of integration tests can be delayed, while waiting for Neo4j to finish its booting. I've also added a note that explain what our fork is about, but obviously that can be removed.

Thanks for writing the plug-in!


