### PR TITLE
Adding serverReadyAttempts

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.github.harti2006</groupId>
     <artifactId>integration-tests</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -82,6 +82,7 @@
                     <password>${neo4j-server.password}</password>
                     <version>${neo4j-server.version}</version>
                     <deleteDb>true</deleteDb>
+                    <serverReadyAttempts>5</serverReadyAttempts>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
+++ b/src/main/java/com/github/harti2006/neo4j/Neo4jServerMojoSupport.java
@@ -66,6 +66,17 @@ public abstract class Neo4jServerMojoSupport extends AbstractMojo {
     @Parameter(required = true, property = "neo4j-server.deleteDb", defaultValue = "false")
     protected boolean deleteDb;
 
+    /**
+     * Makes this number of attempts to wait for server ready conditions when the Neo4j server is started
+     * in {@link StartNeo4jServerMojo}. After the start command, we check the server by connecting it via
+     * BOLT. If that doesn't work, we start making a connection attempt every second, until we connect it
+     * successfully or we reach a number of attempts equal to this parameter. The time spent this way can be
+     * configured and adapted to your particular situation, e.g., in some busy servers Neo4j can take over
+     * 1 min to start.
+     */
+    @Parameter(required = true, property = "neo4j-server.serverReadyAttempts", defaultValue = "10")
+    protected int serverReadyAttempts = 10;
+
     protected Path getServerLocation() {
         return Paths.get(directory, ARTIFACT_NAME + version);
     }

--- a/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
+++ b/src/main/java/com/github/harti2006/neo4j/StartNeo4jServerMojo.java
@@ -145,16 +145,18 @@ public class StartNeo4jServerMojo extends Neo4jServerMojoSupport {
         }
     }
 
+    /**
+     * @see Neo4jServerMojoSupport#serverReadyAttempts.
+     */
     private void checkServerReady() throws MojoExecutionException, InterruptedException {
         // If the deleteDb parameter is true, at this point we have created a new server, which have the
         // default
         // password, and we're about to change this.
         //
         String pwd = deleteDb ? "neo4j" : password;
-        int maxAttempts = 10;
         Thread.sleep(1500); // It takes some time anyway
 
-        for (int attempts = 1; attempts <= maxAttempts; attempts++) {
+        for (int attempts = 1; attempts <= serverReadyAttempts; attempts++) {
             getLog().debug("Trying to connect Neo4j, attempt " + attempts);
 
             try (Driver driver = GraphDatabase.driver("bolt://127.0.0.1:" + boltPort,
@@ -164,7 +166,10 @@ public class StartNeo4jServerMojo extends Neo4jServerMojoSupport {
                 Thread.sleep(1000);
             }
         }
-        throw new MojoExecutionException("Server doesn't result started after waiting for its boot");
+        throw new MojoExecutionException(String.format (
+        		"Server doesn't result started after waiting %ss for its boot",
+        		1.5 + serverReadyAttempts
+        ));
     }
 
     private void setNewPassword() {


### PR DESCRIPTION
Hi André, 

I needed to add the plug-in option serverReadyAttempts (see com.github.harti2006.neo4j.Neo4jServerMojoSupport). We have a busy server and I think this option makes it possible to adapt to different environment, where there might or might not be significant delays.